### PR TITLE
[feat] : 폴더별 경험 조회 API 연동

### DIFF
--- a/src/api/Folder.ts
+++ b/src/api/Folder.ts
@@ -40,7 +40,7 @@ export async function getFolderLists(folder?: string, lastRecordId?: number) {
     });
 
     if (response.data.is_success) {
-      return response.data.data.recordDtoList;
+      return response.data.data;
     }
   } catch (error) {
     console.error(error);

--- a/src/api/Folder.ts
+++ b/src/api/Folder.ts
@@ -1,5 +1,6 @@
 import { AxiosError } from 'axios';
 import api from './instance';
+import { FolderListProps } from '@/types/Folder';
 
 /**
  * [6.1] 폴더 추가하기
@@ -59,6 +60,32 @@ export async function getFolders() {
     }
   } catch (error) {
     console.error(error);
+  }
+}
+
+/**
+ * [6.4] 폴더명 수정하기
+ * @param folderId - 변경할 폴더의 Id
+ * @param title - 변경할 폴더 이름
+ * @returns
+ */
+export async function patchFolderName({ folderId, title }: FolderListProps) {
+  try {
+    const response = await api.patch('/api/folders', {
+      folderId,
+      title,
+    });
+    if (response.data.is_success) {
+      return response.data;
+    }
+  } catch (error) {
+    if (error instanceof AxiosError && error.response) {
+      const errorMessage = error.response.data?.message || '서버 오류가 발생했습니다.';
+      alert(errorMessage);
+    } else {
+      console.error(error);
+      alert('서버와의 연결에 실패했습니다.');
+    }
   }
 }
 

--- a/src/api/Folder.ts
+++ b/src/api/Folder.ts
@@ -1,24 +1,45 @@
+import { AxiosError } from 'axios';
 import api from './instance';
 
 /**
  * [6.1] 폴더 추가하기
+ * @returns
  */
 export async function postNewFolder(title: string) {
   try {
-    const token = localStorage.getItem('accessToken');
-
-    const response = await api.post(
-      '/api/folders',
-      { title },
-      {
-        headers: {
-          Authorization: token ? `Bearer ${token}` : '',
-        },
-      },
-    );
+    const response = await api.post('/api/folders', title, {});
 
     if (response.data.is_success) {
-      return response.data.folderDtoList[0].title; // 이 부분 경험 기록 폴더 추가하면서 다시 고민해야한다!
+      return response.data;
+    }
+  } catch (error) {
+    if (error instanceof AxiosError && error.response) {
+      const errorMessage = error.response.data?.message || '서버 오류가 발생했습니다.';
+      alert(errorMessage);
+    } else {
+      console.error(error);
+      alert('서버와의 연결에 실패했습니다.');
+    }
+  }
+}
+
+/**
+ * [6.2] 폴더별 경험 기록 리스트 조회
+ * @param folder - (optional) 폴더명
+ * @param lastRecordId - (optional) 마지막으로 조회한 RecordId
+ * @returns
+ */
+export async function getFolderLists(folder?: string, lastRecordId?: number) {
+  try {
+    const response = await api.get('/api/folders', {
+      params: {
+        folder: folder || 'all',
+        lastRecordId: lastRecordId || 0,
+      },
+    });
+
+    if (response.data.is_success) {
+      return response.data.data.recordDtoList;
     }
   } catch (error) {
     console.error(error);
@@ -27,19 +48,29 @@ export async function postNewFolder(title: string) {
 
 /**
  * [6.3] 폴더 리스트 조회하기
+ * @returns
  */
 export async function getFolders() {
   try {
-    const token = localStorage.getItem('accessToken');
-
-    const response = await api.get('/api/folders', {
-      headers: {
-        Authorization: token ? `Bearer ${token}` : '',
-      },
-    });
+    const response = await api.get('/api/folders');
 
     if (response.data.is_success) {
-      return response.data.folderDtoList;
+      return response.data.data.folderDtoList;
+    }
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+/**
+ * [6.5] 폴더 삭제하기
+ * @returns
+ */
+export async function deleteFolder(folderId: number) {
+  try {
+    const response = await api.delete(`/api/folders/${folderId}`);
+    if (response.data.is_success) {
+      return response.data;
     }
   } catch (error) {
     console.error(error);

--- a/src/components/common/bottomSheet/FolderBottomSheet.tsx
+++ b/src/components/common/bottomSheet/FolderBottomSheet.tsx
@@ -5,10 +5,10 @@ import { BottomSheet } from './BottomSheet';
 import * as S from './FolderBottomSheet.Style';
 import { SelectBox } from '../selectbox/SelectBox';
 import CloseIcon from '@icons/CloseIcon.svg';
+import { postNewFolder } from '@/api/Folder';
 
 interface FolderBottomSheetProps {
   onClick: () => void;
-  onClickButton: () => void;
   title: string;
   text: string;
   isSelectBox?: boolean;
@@ -23,7 +23,6 @@ const FOLDER_DATA = [
 /**
  *
  * @param onClick - BottomSheet 열고 닫는 함수
- * @param onClickButton - Button 클릭 시 수행하는 함수
  * @param title - BottomSheet의 제목
  * @param text - BottomSheet의 부가 설명
  * @param isSelectBox - (optional) true일 경우 selectBox나옴
@@ -31,7 +30,6 @@ const FOLDER_DATA = [
  */
 export const FolderBottomSheet = ({
   onClick,
-  onClickButton,
   title,
   text,
   isSelectBox = false,
@@ -52,6 +50,14 @@ export const FolderBottomSheet = ({
     setFolderName(select);
   };
 
+  const handleClickButton = async () => {
+    if (title === '새 폴더 추가하기') {
+      const response = await postNewFolder(folderName);
+      if (response.is_success) {
+        onClick();
+      }
+    }
+  };
   return (
     <BottomSheet onClick={onClick}>
       <S.Header>
@@ -71,7 +77,11 @@ export const FolderBottomSheet = ({
             onChange={changeFolderName}
           />
         )}
-        <Button styleType="basic" disabled={folderName === '' || isError} onClick={onClickButton}>
+        <Button
+          styleType="basic"
+          disabled={folderName === '' || isError}
+          onClick={handleClickButton}
+        >
           완료
         </Button>
       </S.SheetContent>

--- a/src/components/list/content/Content.tsx
+++ b/src/components/list/content/Content.tsx
@@ -2,67 +2,26 @@ import { useNavigate } from 'react-router-dom';
 import * as S from './Content.Style';
 import { List } from '../../common/list/List';
 import { Empty } from '@/components/common/empty/Empty';
+import { ListProps } from '@/types/Folder';
 
-interface ListItem {
-  id: number;
-  title: string;
-  chips: string[];
-  date: string;
+interface ContentProps {
+  listData: ListProps[];
 }
 
-const LISTDATA: ListItem[] = [
-  {
-    id: 1,
-    title: '프로젝트 진행 계획서',
-    chips: ['창의력', '커뮤니케이션', '문제 해결'],
-    date: '2024.10.25',
-  },
-  {
-    id: 2,
-    title: '프로젝트 진행 계획서',
-    chips: ['창의력', '커뮤니케이션', '문제 해결'],
-    date: '2024.10.25',
-  },
-  {
-    id: 1,
-    title: '프로젝트 진행 계획서',
-    chips: ['창의력', '커뮤니케이션', '문제 해결'],
-    date: '2024.10.25',
-  },
-  {
-    id: 2,
-    title: '프로젝트 진행 계획서',
-    chips: ['창의력', '커뮤니케이션', '문제 해결'],
-    date: '2024.10.25',
-  },
-  {
-    id: 1,
-    title: '프로젝트 진행 계획서',
-    chips: ['창의력', '커뮤니케이션', '문제 해결'],
-    date: '2024.10.25',
-  },
-  {
-    id: 2,
-    title: '프로젝트 진행 계획서',
-    chips: ['창의력', '커뮤니케이션', '문제 해결'],
-    date: '2024.10.25',
-  },
-]; // 추후 백엔드에서 받아오면 다른 방식으로 변경할 것!
-
-export const Content = () => {
+export const Content = ({ listData }: ContentProps) => {
   const navigate = useNavigate();
 
   return (
     <S.Content>
-      {LISTDATA.length > 0 ? (
-        LISTDATA.map((item, index) => (
+      {listData.length > 0 ? (
+        listData.map((item) => (
           <List
-            key={index}
+            key={item.analysisId}
             title={item.title}
-            chips={item.chips}
-            date={item.date}
+            chips={item.keywordList}
+            date={item.createdAt}
             onClick={() => {
-              navigate(`/report/${item.id}`);
+              navigate(`/report/${item.analysisId}`);
             }}
           />
         ))

--- a/src/components/list/header/Header.tsx
+++ b/src/components/list/header/Header.tsx
@@ -3,10 +3,11 @@ import * as S from './Header.Style';
 import { CategoryChip } from '../../common/chip/CategoryChip';
 import FolderIcon from '@icons/FolderIcon.svg';
 import { Header } from '@/components/layout/header/Header';
+import { FolderListProps } from '@/types/Folder';
 
 interface ListHeaderProps {
   nickname: string;
-  folderData: string[] | null;
+  folderData: FolderListProps[];
   selectFolder: string;
   onClick: (folderName: string) => void;
   onClickSideBar: () => void;
@@ -44,13 +45,13 @@ export const ListHeader = ({
         </S.FolderIcon>
         <S.ChipContainer>
           {folderData &&
-            folderData.map((item, index) => (
+            folderData.map((item) => (
               <CategoryChip
-                key={index}
-                isSelected={item === selectFolder}
-                onClick={() => onClick(item)}
+                key={item.folderId}
+                isSelected={item.title === selectFolder}
+                onClick={() => onClick(item.title)}
               >
-                {item}
+                {item.title}
               </CategoryChip>
             ))}
         </S.ChipContainer>

--- a/src/pages/folderPage/FolderPage.Style.ts
+++ b/src/pages/folderPage/FolderPage.Style.ts
@@ -29,3 +29,15 @@ export const Icon = styled.img`
   width: 1.5rem;
   height: 1.5rem;
 `;
+
+export const Input = styled.input`
+  width: 90%;
+  height: 3rem;
+  border: none;
+  outline: none;
+  text-align: center;
+  font-size: 1rem;
+  font-weight: 600;
+  color: ${({ theme }) => theme.colors.gray800};
+  background-color: ${({ theme }) => theme.colors.blue50};
+`;

--- a/src/pages/folderPage/FolderPage.tsx
+++ b/src/pages/folderPage/FolderPage.tsx
@@ -6,7 +6,7 @@ import { FolderBottomSheet } from '@components/common/bottomSheet/FolderBottomSh
 import { DetailModal } from '@components/common/modal/DetailModal';
 import DeleteIcon from '@icons/DeleteIcon.svg';
 import PlusIcon from '@icons/PlusIcon.svg';
-import { deleteFolder, getFolders } from '@/api/Folder';
+import { deleteFolder, getFolders, patchFolderName } from '@/api/Folder';
 import { FolderListProps } from '@/types/Folder';
 
 export const FolderPage = () => {
@@ -24,7 +24,7 @@ export const FolderPage = () => {
       }
     };
     fetchUser();
-  }, []);
+  }, [openBottom]);
 
   const toggleBottomSheet = () => {
     setOpenBottom((prev) => !prev);
@@ -49,6 +49,19 @@ export const FolderPage = () => {
     }
   };
 
+  const handleKeyDown = async (
+    event: React.KeyboardEvent<HTMLInputElement>,
+    folderId: number,
+    title: string,
+  ) => {
+    if (event.key === 'Enter') {
+      const response = await patchFolderName({ folderId, title });
+      if (response.is_success) {
+        toggleBottomSheet();
+      }
+    }
+  };
+
   return (
     <div>
       <TabBar centerText="폴더 관리" rightText="편집" onClick={handleEdit} />
@@ -69,7 +82,24 @@ export const FolderPage = () => {
                 />
               )}
               <Folder type="folder">
-                <h6>{folder.title}</h6>
+                {isEditing ? (
+                  <S.Input
+                    value={folder.title}
+                    type="text"
+                    onChange={(e) => {
+                      setFolderList((prev) =>
+                        prev.map((f) =>
+                          f.folderId === folder.folderId ? { ...f, title: e.target.value } : f,
+                        ),
+                      );
+                    }}
+                    onKeyDown={(e) => {
+                      handleKeyDown(e, folder.folderId, folder.title);
+                    }}
+                  />
+                ) : (
+                  <h6>{folder.title}</h6>
+                )}
               </Folder>
             </S.FolderContainer>
           ))}

--- a/src/pages/folderPage/FolderPage.tsx
+++ b/src/pages/folderPage/FolderPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Folder } from '@components/folder/Folder';
 import { TabBar } from '@components/layout/tabBar/TabBar';
 import * as S from './FolderPage.Style';
@@ -6,24 +6,14 @@ import { FolderBottomSheet } from '@components/common/bottomSheet/FolderBottomSh
 import { DetailModal } from '@components/common/modal/DetailModal';
 import DeleteIcon from '@icons/DeleteIcon.svg';
 import PlusIcon from '@icons/PlusIcon.svg';
-
-const FOLDER_DATA = [
-  '큐시즘 밋업',
-  '프로젝트 공모전',
-  '아르바이트',
-  '1',
-  '2',
-  'dkdkd',
-  'dksdusd',
-  '하...',
-  '취업해요',
-  '큐시즘 사랑',
-] as string[];
+import { getFolders } from '@/api/Folder';
+import { FolderListProps } from '@/types/Folder';
 
 export const FolderPage = () => {
   const [openBottom, setOpenBottom] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [openModal, setOpenModal] = useState(false);
+  const [folderList, setFolderList] = useState<FolderListProps[]>([]);
 
   const toggleBottomSheet = () => {
     setOpenBottom((prev) => !prev);
@@ -37,6 +27,17 @@ export const FolderPage = () => {
     setOpenModal((prev) => !prev);
   };
 
+  useEffect(() => {
+    const fetchUser = async () => {
+      const folderList = await getFolders();
+      if (folderList) {
+        setFolderList(folderList);
+      }
+    };
+
+    fetchUser();
+  }, []);
+
   return (
     <div>
       <TabBar centerText="폴더 관리" rightText="편집" onClick={handleEdit} />
@@ -46,12 +47,12 @@ export const FolderPage = () => {
             <img src={PlusIcon} alt="plusButton" />
           </Folder>
         )}
-        {FOLDER_DATA.length > 0 &&
-          FOLDER_DATA.map((folder) => (
-            <S.FolderContainer key={folder}>
+        {folderList.length > 0 &&
+          folderList.map((folder) => (
+            <S.FolderContainer key={folder.folderId}>
               {isEditing && <S.Icon src={DeleteIcon} alt="delete" onClick={toggleModal} />}
               <Folder type="folder">
-                <h6>{folder}</h6>
+                <h6>{folder.title}</h6>
               </Folder>
             </S.FolderContainer>
           ))}

--- a/src/pages/folderPage/FolderPage.tsx
+++ b/src/pages/folderPage/FolderPage.tsx
@@ -59,9 +59,6 @@ export const FolderPage = () => {
       {openBottom && (
         <FolderBottomSheet
           onClick={toggleBottomSheet}
-          onClickButton={() => {
-            console.log('구현 해야함');
-          }}
           title="새 폴더 추가하기"
           text="추가할 폴더의 이름을 적어주세요."
         />

--- a/src/pages/folderPage/FolderPage.tsx
+++ b/src/pages/folderPage/FolderPage.tsx
@@ -55,10 +55,7 @@ export const FolderPage = () => {
     title: string,
   ) => {
     if (event.key === 'Enter') {
-      const response = await patchFolderName({ folderId, title });
-      if (response.is_success) {
-        toggleBottomSheet();
-      }
+      await patchFolderName({ folderId, title });
     }
   };
 

--- a/src/pages/listPage/ListPage.tsx
+++ b/src/pages/listPage/ListPage.tsx
@@ -1,20 +1,22 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ListHeader } from '@components/list/header/Header';
 import { Content } from '@components/list/content/Content';
 import * as S from './ListPage.Style';
 import { RecordBottomSheet } from '@components/common/bottomSheet/RecordBottomSheet';
 import { SideBar } from '@/components/common/sideBar/SideBar';
 import { FloatingButton } from '@/components/common/button/FloatingButton';
+import { getFolders } from '@/api/Folder';
+import { FolderListProps } from '@/types/Folder';
 
 //@TODO
 // 1. 닉네임을 백에서 직접 받아와서 Header에 처리해야한다!
 // 2. 경험 리스트가 아예 없을 때 에러 없이 되는지 또 다시 한번 확인하기!
 
-const FOLDERDATA = ['전체', '밋업 프로젝트'];
 export const ListPage = () => {
   const [selectFolder, setSelectFolder] = useState('전체');
   const [openBottom, setOpenBottom] = useState(false);
   const [openSideBar, setOpenSideBar] = useState(false);
+  const [folderList, setFolderList] = useState<FolderListProps[]>([]);
 
   const handleSelectFolder = (folderName: string) => {
     setSelectFolder(folderName);
@@ -28,11 +30,22 @@ export const ListPage = () => {
     setOpenSideBar((prev) => !prev);
   };
 
+  useEffect(() => {
+    const fetchUser = async () => {
+      const folderList = await getFolders();
+      if (folderList) {
+        setFolderList(folderList);
+      }
+    };
+
+    fetchUser();
+  }, []);
+
   return (
     <S.ListPage>
       <ListHeader
         nickname="코코"
-        folderData={FOLDERDATA}
+        folderData={folderList}
         selectFolder={selectFolder}
         onClick={handleSelectFolder}
         onClickSideBar={toggleSideBar}

--- a/src/pages/listPage/ListPage.tsx
+++ b/src/pages/listPage/ListPage.tsx
@@ -40,7 +40,7 @@ export const ListPage = () => {
       }
 
       const listData = await getFolderLists(selectFolder);
-      if (listData) {
+      if (listData.recordDtoList) {
         setListData(listData);
       }
     };

--- a/src/pages/listPage/ListPage.tsx
+++ b/src/pages/listPage/ListPage.tsx
@@ -5,18 +5,20 @@ import * as S from './ListPage.Style';
 import { RecordBottomSheet } from '@components/common/bottomSheet/RecordBottomSheet';
 import { SideBar } from '@/components/common/sideBar/SideBar';
 import { FloatingButton } from '@/components/common/button/FloatingButton';
-import { getFolders } from '@/api/Folder';
-import { FolderListProps } from '@/types/Folder';
+import { getFolderLists, getFolders } from '@/api/Folder';
+import { FolderListProps, ListProps } from '@/types/Folder';
 
 //@TODO
 // 1. 닉네임을 백에서 직접 받아와서 Header에 처리해야한다!
 // 2. 경험 리스트가 아예 없을 때 에러 없이 되는지 또 다시 한번 확인하기!
 
 export const ListPage = () => {
-  const [selectFolder, setSelectFolder] = useState('전체');
+  const [selectFolder, setSelectFolder] = useState('');
+  //const [lastRecordId, setLastRecordId] = useState(0);
   const [openBottom, setOpenBottom] = useState(false);
   const [openSideBar, setOpenSideBar] = useState(false);
   const [folderList, setFolderList] = useState<FolderListProps[]>([]);
+  const [listData, setListData] = useState<ListProps[]>([]);
 
   const handleSelectFolder = (folderName: string) => {
     setSelectFolder(folderName);
@@ -36,10 +38,15 @@ export const ListPage = () => {
       if (folderList) {
         setFolderList(folderList);
       }
+
+      const listData = await getFolderLists(selectFolder);
+      if (listData) {
+        setListData(listData);
+      }
     };
 
     fetchUser();
-  }, []);
+  }, [selectFolder]);
 
   return (
     <S.ListPage>
@@ -50,7 +57,7 @@ export const ListPage = () => {
         onClick={handleSelectFolder}
         onClickSideBar={toggleSideBar}
       />
-      <Content />
+      <Content listData={listData} />
       <FloatingButton onClick={toggleBottomSheet} />
       {openBottom && <RecordBottomSheet onClick={toggleBottomSheet} />}
       {openSideBar && <SideBar onClick={toggleSideBar} />}

--- a/src/pages/memoPage/MemoPage.tsx
+++ b/src/pages/memoPage/MemoPage.tsx
@@ -15,7 +15,12 @@ const DUMMY_MEMO = {
   memo: '오늘은 큐시즘에서 서비스 기획을 했따',
 };
 
-const categoryData = ['큐시즘 서비스 기획', '마이리얼트립 인턴', '서비스디자인학과 팀 프로젝트', '회사문장'];
+const categoryData = [
+  '큐시즘 서비스 기획',
+  '마이리얼트립 인턴',
+  '서비스디자인학과 팀 프로젝트',
+  '회사문장',
+];
 
 export const MemoPage = () => {
   const navigate = useNavigate();
@@ -115,10 +120,6 @@ export const MemoPage = () => {
 
   const isSaveDisabled = !tempMemo.memo;
 
-  function handleBottomSheetComplete(): void {
-    setIsBottomSheetOpen(false);
-  }
-
   return (
     <S.Container>
       <S.HeaderContainer>
@@ -202,7 +203,6 @@ export const MemoPage = () => {
       {isBottomSheetOpen && (
         <FolderBottomSheet
           onClick={() => setIsBottomSheetOpen(false)}
-          onClickButton={handleBottomSheetComplete}
           title="새 폴더 추가하기"
           text="추가할 폴더의 이름을 적어주세요"
         />

--- a/src/pages/recordCompletePage/RecordCompletePage.tsx
+++ b/src/pages/recordCompletePage/RecordCompletePage.tsx
@@ -7,10 +7,35 @@ import * as S from './RecordCompletePage.Style';
 import { getFormattedDate } from '@/utils/dateUtils';
 import FolderIcon from '@icons/FolderIcon.svg';
 
-const categoryData = ['큐시즘 서비스 기획', '밋업 프로젝트', '뤼튼', '멍냥부리', '새 폴더 추가하기', '카테고리 수정하기', '카테고리 삭제하기', '카테고리 복사하기', '카테고리 이름 변경하기', '사과', '바나나', '딸기', '포도', '라임', '레몬', '자몽', '라임', '레몬', '자몽', '라임', '레몬', '자몽',];
+const categoryData = [
+  '큐시즘 서비스 기획',
+  '밋업 프로젝트',
+  '뤼튼',
+  '멍냥부리',
+  '새 폴더 추가하기',
+  '카테고리 수정하기',
+  '카테고리 삭제하기',
+  '카테고리 복사하기',
+  '카테고리 이름 변경하기',
+  '사과',
+  '바나나',
+  '딸기',
+  '포도',
+  '라임',
+  '레몬',
+  '자몽',
+  '라임',
+  '레몬',
+  '자몽',
+  '라임',
+  '레몬',
+  '자몽',
+];
 
 export const RecordCompletePage = () => {
-  const [recordSummary] = useState('경쟁 서비스 기능, 사용자 인터페이스(UI), 요금제 등을 분석하고 글로벌 시장에서 주요 플레이어들의 특징을 파악한 점은 서비스 기획 직무에서 필수적인 시장 분석 능력을 잘 보여줍니다.');
+  const [recordSummary] = useState(
+    '경쟁 서비스 기능, 사용자 인터페이스(UI), 요금제 등을 분석하고 글로벌 시장에서 주요 플레이어들의 특징을 파악한 점은 서비스 기획 직무에서 필수적인 시장 분석 능력을 잘 보여줍니다.',
+  );
   const [title, setTitle] = useState(getFormattedDate());
   const [content, setContent] = useState(recordSummary);
   const [selectedCategory, setSelectedCategory] = useState('');
@@ -36,11 +61,6 @@ export const RecordCompletePage = () => {
     e.preventDefault();
   };
 
-
-  const handleBottomSheetComplete = () => {
-    setIsBottomSheetOpen(false);
-  };
-
   const handleSaveButton = () => {
     // 저장 로직 구현
     navigate('/home');
@@ -52,7 +72,11 @@ export const RecordCompletePage = () => {
     <S.Container>
       <S.HeaderContainer>
         <S.Title>경험 기록이 완료되었어요!</S.Title>
-        <S.SubTitle>코코님의 경험을 모아서<br />한눈에 보기 쉽게 요약해드렸어요</S.SubTitle>
+        <S.SubTitle>
+          코코님의 경험을 모아서
+          <br />
+          한눈에 보기 쉽게 요약해드렸어요
+        </S.SubTitle>
       </S.HeaderContainer>
 
       <S.Form onSubmit={handleSubmit}>
@@ -63,10 +87,7 @@ export const RecordCompletePage = () => {
           isError={false}
         />
         <S.Line />
-        <S.TextArea
-          value={content}
-          onChange={handleChangeContent}
-        />
+        <S.TextArea value={content} onChange={handleChangeContent} />
         <S.Line />
 
         <S.Label>경험의 카테고리를 선택해주세요.</S.Label>
@@ -99,7 +120,6 @@ export const RecordCompletePage = () => {
       {isBottomSheetOpen && (
         <FolderBottomSheet
           onClick={() => setIsBottomSheetOpen(false)}
-          onClickButton={handleBottomSheetComplete}
           title="새 폴더 추가하기"
           text="추가할 폴더의 이름을 적어주세요"
         />

--- a/src/pages/reportPage/ReportPage.tsx
+++ b/src/pages/reportPage/ReportPage.tsx
@@ -115,9 +115,6 @@ export const ReportPage = () => {
       {openChangeBottom && (
         <FolderBottomSheet
           onClick={toggleChangeFoler}
-          onClickButton={() => {
-            console.log('구현해야함');
-          }}
           title="폴더 변경하기"
           text="저장할 폴더를 선택해주세요"
           isSelectBox={true}

--- a/src/types/Folder.ts
+++ b/src/types/Folder.ts
@@ -2,3 +2,12 @@ export interface FolderListProps {
   folderId: number;
   title: string;
 }
+
+export interface ListProps {
+  analysisId: number;
+  recordId: number;
+  folder: string;
+  title: string;
+  keywordList: string[];
+  createdAt: string;
+}

--- a/src/types/Folder.ts
+++ b/src/types/Folder.ts
@@ -1,0 +1,4 @@
+export interface FolderListProps {
+  folderId: number;
+  title: string;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

>  연관된 이슈 번호를 작성해주세요.
#103 

## 📝작업 내용

> 작업한 내용을 작성해주세요.
- 폴더 관리 페이지에서 폴더 조회 완료 ! 
- 폴더 관리 페이지에서 삭제, 추가 완료!
- 새폴더 추가하기 바텀 시트에서 폴더명 새로 추가하는 거 완료!
- 경험 리스트 페이지에서 경험 조회는 기록 완료된 다음에 다시 한번 확인해보겠습니당! 

### 스크린샷 (선택)
- [6.1] 폴더 추가하기 
![image](https://github.com/user-attachments/assets/4545bf9c-27c1-4569-a11b-2233c424f2d9)
- [6.2] 폴더별 경험 기록 리스트 조회
![image](https://github.com/user-attachments/assets/2df2d0d8-9e20-4cb5-ad4d-564a4ffb9478)
- [6.3] 폴더 리스트 조회하기
![image](https://github.com/user-attachments/assets/66a7865a-190c-418c-a8a7-994a880e8df8)
- [6.4] 잘됨!!
- [6.5] 폴더 삭제하
![image](https://github.com/user-attachments/assets/61f391b1-ad12-45f6-9c2d-2f8ee9cbae31)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- 모달이 열리고 폴더명을 수정하고 다시 모달이 닫히면 기존에 있던 폴더 리스트가 업데이트 되지 않습니다! 그래서 저는 폴더 리스트를 불러오는 useEffect에서 openBottom이 변경될 때에도 get 요청을 다시 하게 해보았습니다!! 
```
  useEffect(() => {
    const fetchUser = async () => {
      const folderList = await getFolders();
      if (folderList) {
        setFolderList(folderList);
      }
    };
    fetchUser();
  }, [openBottom]);
```
